### PR TITLE
adjusted IT text in final test

### DIFF
--- a/test/promise-katas-2-spec.js
+++ b/test/promise-katas-2-spec.js
@@ -29,7 +29,7 @@ describe('dog', () => {
 });
 
 describe('joke', () => {
-    it('returns a joke, waits 1000ms and then returns the answer', async () => {
+    it('returns a joke and answer, using Promise.all to fire of multiple requests at the same time.', async () => {
         expect(await joke()).to.deep.equal({ 
             question: "Why did the scarecrow win the Nobel Prize?", 
             answer: "Because he was out-standing in his field."


### PR DESCRIPTION
Update text of final test in katas 2 so it doesn't confuse students,  make it more difficult than it needs to be for students first set of katas with promise/then.